### PR TITLE
Fixes parameter adjustment demo (scheme -> state)

### DIFF
--- a/demo_files/model_comparison/parameter_adjustments/base/setup.json
+++ b/demo_files/model_comparison/parameter_adjustments/base/setup.json
@@ -23,7 +23,7 @@
             {
                 "variable": "m_kinetics",
                 "isotype": 1,
-                "scheme": 3,
+                "state": 3,
                 "transition": 2,
                 "parameter_number": 1,
                 "multipliers": [1, 1, 1, 0.5, 0.5],

--- a/docs/pages/demos/model_comparison/parameter_adjustments/parameter_adjustments.md
+++ b/docs/pages/demos/model_comparison/parameter_adjustments/parameter_adjustments.md
@@ -85,7 +85,7 @@ The only difference between this simulation and the [single pCa curve](../../pCa
             {
                 "variable": "m_kinetics",
                 "isotype": 1,
-                "scheme": 3,
+                "state": 3,
                 "transition": 2,
                 "parameter_number": 1,
                 "multipliers": [1, 1, 1, 0.5, 0.5],
@@ -119,7 +119,7 @@ The details are as follows:
             {
                 "variable": "m_kinetics",
                 "isotype": 1,
-                "scheme": 3,
+                "state": 3,
                 "transition": 2,
                 "parameter_number": 1,
                 "multipliers": [1, 1, 1, 0.5, 0.5],
@@ -127,7 +127,7 @@ The details are as follows:
             }
 ```
 
-+ During the 5 trials adjust `parameter_number` 1 in the kinetics for myosin `isotype` 1, `scheme` 3, `transition` 2 to 1, 1, 1, 0.5, 0.5 times its value in the base model
++ During the 5 trials adjust `parameter_number` 1 in the kinetics for myosin `isotype` 1, `state` 3, `transition` 2 to 1, 1, 1, 0.5, 0.5 times its value in the base model
 + If the variable is changed to `c_kinetics`, the parameters for cMyBP-C transitions will be adjusted instead.
 
 This nomenclature is a bit more complicated but should be easier to understand when viewed in conjunction with the same section from the base model file.
@@ -135,9 +135,7 @@ This nomenclature is a bit more complicated but should be easier to understand w
 ```
 "m_kinetics": [
     {
-      "no_of_states": 4,
-      "max_no_of_transitions": 2,
-      "scheme": [
+    "state": [
         {
             <snip>
         },


### PR DESCRIPTION
Hi again - 

When running the demo `model comparison/parameter adjustment` I was met with an error: 

```
  y = np.asarray(adj_model[a['variable']][a['isotype']-1]['state'][a['state']-1] \
                                                                     ~^^^^^^^^^
KeyError: 'state'
```
which is from line 176 of `characterize_model.py`. It seems this is where FiberPy is generating the new JSON models from the base model. 

The `manipulations` section in the current `setup.json` uses the terminology `scheme` to identify the state to manipulate. 

In this example from the docs the `m_kinetics` also has a `scheme` section:

```
"m_kinetics": [
    {
      "no_of_states": 4,
      "max_no_of_transitions": 2,
      "scheme": [
...
```
However, the other example models use the term` state` in place of scheme. So, when executed as is, I am guessing `characterize_model.py` tries to subset the JSON key value pair looking for a `state` key/value and cannot because it is labeled `scheme`.

In this pull request, I replaced `scheme` with `state` in the `setup.json` which fixes the issue in this demo example, and I am able to run the example. I also updated the docs page to reflect the same.

Note, the issue can also be fixed altering the `characterize_model.py` file from `state` to `scheme` around lines 176, but since most other examples use the `state` terminology I made a guess that there was a change in interface at some point to `state`, but I could be wrong. 

Either way I hope this helps, and thank you all for the work and allowing us to use your tools!

-Brent
